### PR TITLE
Applied safety check when accessing creation time

### DIFF
--- a/android/src/main/java/com/mybigday/rnmediameta/RNMediaMeta.java
+++ b/android/src/main/java/com/mybigday/rnmediameta/RNMediaMeta.java
@@ -110,7 +110,11 @@ public class RNMediaMeta extends ReactContextBaseJavaModule {
       }
 
       // Legacy support & camelCase
-      result.putString("createTime", result.getString("creation_time"));
+      // Only get the createTime if it exists.
+      // Otherwise an exception is thrown and thumb is never generated
+      if (result.hasKey("createTime")) {
+        result.putString("createTime", result.getString("creation_time"));
+      }
 
       if (options.getBoolean("getThumb")) {
         // get thumb


### PR DESCRIPTION
When trying to get the `creation_time` attribute when it doesn't exist will thrown an exception and will cause the thumb to never be generated. Added a safety check before accessing.